### PR TITLE
Add -e flag to run ensure before commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ gop run [-w] [target_name]
 
 ### test
 
-Run `go test` on the src directory.
+Run `go test` on the src directory. If you want to execute ensure before build, you can use `-e` flag.
 
 ```
-gop test [target_name]
+gop test [-e] [target_name]
 ```
 
 ### release

--- a/README.md
+++ b/README.md
@@ -143,16 +143,16 @@ gop rm <package1> <package2>
 
 ### build
 
-Run `go build` on the src directory.
+Run `go build` on the src directory. If you want to execute ensure before build, you can use `-e` flag.
 
 ```
-gop build [target_name]
+gop build [-e] [target_name]
 ```
 
 ### run
 
 Run `go run` on the src directory. `-w` will monitor the go source code changes and
-automatically build and run again.
+automatically build and run again. `-e` will automatically execute `ensure` before every time build.
 
 ```
 gop run [-w] [target_name]

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -144,7 +144,7 @@ gop rm <package>
 
 ### build
 
-`go build` 编译目标。
+`go build` 编译目标。如果希望在编译之前自动之行 `ensure` 命令，可以使用 `-e`。
 
 ```
 gop build [-e] [target_name]
@@ -161,10 +161,10 @@ gop run [-w] [-e] [target_name]
 
 ### test
 
-运行 `go test` 将执行单元测试.
+运行 `go test` 将执行单元测试. 如果希望在编译之前自动之行 `ensure` 命令，可以使用 `-e`。
 
 ```
-gop test [target_name]
+gop test [-e] [target_name]
 ```
 
 ### release

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -147,15 +147,16 @@ gop rm <package>
 `go build` 编译目标。
 
 ```
-gop build [target_name]
+gop build [-e] [target_name]
 ```
 
 ### run
 
-`go run` 编译并运行目标。`-w` 参数将会监视源代码中的Go文件变动并自动重新编译和运行。
+`go run` 编译并运行目标。`-w` 参数将会监视源代码中的Go文件变动并自动重新编译和运行。`-e` 参数将会在每次进行
+编译之前先调用`ensure`确保所有的依赖项都拷贝到了vendor下。
 
 ```
-gop run [-w] [target_name]
+gop run [-w] [-e] [target_name]
 ```
 
 ### test

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -86,7 +86,7 @@ func analysisTarget(level int, targetName, projectRoot string) error {
 	return nil
 }
 
-func runBuildNoCtx(args []string, isWindows bool) error {
+func runBuildNoCtx(ctx *cli.Context, args []string, isWindows, ensureFlag bool) error {
 	level, projectRoot, err := analysisDirLevel()
 	if err != nil {
 		return err
@@ -112,6 +112,17 @@ func runBuildNoCtx(args []string, isWindows bool) error {
 			showLog = true
 		} else if arg == "-o" {
 			find = i
+		}
+	}
+
+	if ensureFlag {
+		globalGoPath, ok := os.LookupEnv("GOPATH")
+		if !ok {
+			return errors.New("Not found GOPATH")
+		}
+
+		if err = ensure(ctx, globalGoPath, projectRoot, curTarget); err != nil {
+			return err
 		}
 	}
 
@@ -158,6 +169,17 @@ func runBuildNoCtx(args []string, isWindows bool) error {
 }
 
 func runBuild(ctx *cli.Context) error {
-	return runBuildNoCtx(ctx.Args(), os.Getenv("GOOS") == "windows" ||
-		(os.Getenv("GOOS") == "" && runtime.GOOS == "windows"))
+	args := ctx.Args()
+	var ensureFlagIdx = -1
+	for i, arg := range args {
+		if arg == "-e" {
+			ensureFlagIdx = i
+		}
+	}
+	if ensureFlagIdx > -1 {
+		args = append(args[:ensureFlagIdx], args[ensureFlagIdx+1:]...)
+	}
+
+	return runBuildNoCtx(ctx, args, os.Getenv("GOOS") == "windows" ||
+		(os.Getenv("GOOS") == "" && runtime.GOOS == "windows"), ensureFlagIdx > -1)
 }

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -121,7 +121,7 @@ func runBuildNoCtx(ctx *cli.Context, args []string, isWindows, ensureFlag bool) 
 			return errors.New("Not found GOPATH")
 		}
 
-		if err = ensure(ctx, globalGoPath, projectRoot, curTarget); err != nil {
+		if err = ensure(ctx, globalGoPath, projectRoot, curTarget, false); err != nil {
 			return err
 		}
 	}

--- a/cmd/ensure.go
+++ b/cmd/ensure.go
@@ -50,9 +50,9 @@ var CmdEnsure = cli.Command{
 
 var updatedPackage = make(map[string]struct{})
 
-func ensure(ctx *cli.Context, globalGoPath, projectRoot string, target *Target) error {
+func ensure(ctx *cli.Context, globalGoPath, projectRoot string, target *Target, isTest bool) error {
 	vendorDir := filepath.Join(projectRoot, "src", "vendor")
-	imports, err := ListImports(projectRoot, target.Dir, projectRoot, filepath.Join(projectRoot, "src"), ctx.String("tags"), ctx.Bool("test"))
+	imports, err := ListImports(projectRoot, target.Dir, projectRoot, filepath.Join(projectRoot, "src"), ctx.String("tags"), isTest)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func ensure(ctx *cli.Context, globalGoPath, projectRoot string, target *Target) 
 
 			updatedPackage[imp.Name] = struct{}{}
 
-			return ensure(ctx, globalGoPath, projectRoot, target)
+			return ensure(ctx, globalGoPath, projectRoot, target, isTest)
 		}
 
 		exist, err := isDirExist(dstDir)
@@ -120,7 +120,7 @@ func ensure(ctx *cli.Context, globalGoPath, projectRoot string, target *Target) 
 					}
 
 					// scan the package dependencies again since the new package added
-					return ensure(ctx, globalGoPath, projectRoot, target)
+					return ensure(ctx, globalGoPath, projectRoot, target, isTest)
 				}
 
 				fmt.Printf("Package %s not found on $GOPATH, please use -g option or go get at first\n", imp.Name)
@@ -132,7 +132,7 @@ func ensure(ctx *cli.Context, globalGoPath, projectRoot string, target *Target) 
 				return err
 			}
 
-			return ensure(ctx, globalGoPath, projectRoot, target)
+			return ensure(ctx, globalGoPath, projectRoot, target, isTest)
 		}
 	}
 	return nil
@@ -165,5 +165,5 @@ func runEnsure(ctx *cli.Context) error {
 		return err
 	}
 
-	return ensure(ctx, globalGoPath, projectRoot, curTarget)
+	return ensure(ctx, globalGoPath, projectRoot, curTarget, ctx.Bool("test"))
 }

--- a/doc.go
+++ b/doc.go
@@ -121,22 +121,22 @@ Remove one or more packages from this project.
 
 7. build
 
-Run go build on the src directory.
+Run go build on the src directory. If you want to execute ensure before build, you can use `-e` flag.
 
-	gop build [target_name]
+	gop build [-e] [target_name]
 
 8. run
 
 Run go run on the src directory. -w will monitor the go source code changes and
-automatically build and run again.
+automatically build and run again. `-e` will automatically execute `ensure` before every time build.
 
-	gop run [-w] [target_name]
+	gop run [-w] [-e] [target_name]
 
 9. test
 
-Run go test on the src directory.
+Run go test on the src directory. If you want to execute ensure before build, you can use `-e` flag.
 
-	gop test [target_name]
+	gop test [-e] [target_name]
 
 10. release
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// Version of gop
-	Version = "0.6.0629"
+	Version = "0.6.0905"
 )
 
 func main() {


### PR DESCRIPTION
This pull request add -e flag for build, run, test to run ensure before build or test.